### PR TITLE
Fix inability to load aircraft because of pushback error

### DIFF
--- a/F-35B-jsbsim-set.xml
+++ b/F-35B-jsbsim-set.xml
@@ -57,6 +57,9 @@
             <pushback>
                 <target-speed-fps>0</target-speed-fps>
                 <position-norm>0</position-norm>
+                <kp type="double">100</kp>
+                <ki type="double">25</ki>
+                <kd type="double">0</kd>
             </pushback>
 		</model>
 


### PR DESCRIPTION
Loading the JSBSim version of the aircraft led to a `FGPropertyManager::GetNode() No node found for /sim/model/pushback/kp`, causing FlightGear to quit. This small update adds the missing properties, using values mentioned in http://wiki.flightgear.org/Howto:Implement_pushback so that the F-35B (JBSSim) will start. Tested on FlightGear 2018.3.1 on Mac 10.14.1.